### PR TITLE
Fix parser typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublish": "typings install && tsc"
   },
   "dependencies": {
-    "opds-feed-parser": "^0.0.7",
+    "opds-feed-parser": "^0.0.8",
     "react": "^0.14.6",
     "react-dom": "^0.14.6",
     "react-redux": "^4.3.0",

--- a/typings.json
+++ b/typings.json
@@ -1,11 +1,13 @@
 {
   "ambientDependencies": {
+    "core-js": "github:DefinitelyTyped/DefinitelyTyped/core-js/core-js.d.ts#c777572e8532c4d358306fe4c0e17a533f940b04",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
     "react": "github:DefinitelyTyped/DefinitelyTyped/react/react.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
     "react-addons-test-utils": "github:DefinitelyTyped/DefinitelyTyped/react/react-addons-test-utils.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
     "react-dom": "github:DefinitelyTyped/DefinitelyTyped/react/react-dom.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
     "react-redux": "github:DefinitelyTyped/DefinitelyTyped/react-redux/react-redux.d.ts#a513c4df6eb8505da8eef432891c8b69b73535d9",
     "redux": "github:DefinitelyTyped/DefinitelyTyped/redux/redux.d.ts#d4f3ed0cc7f7aba3b47dc6dbc68ead8a97052fe4",
-    "redux-thunk": "github:DefinitelyTyped/DefinitelyTyped/redux-thunk/redux-thunk.d.ts#75249b97104d00c1ca2451ac29369009a5f2b101"
+    "redux-thunk": "github:DefinitelyTyped/DefinitelyTyped/redux-thunk/redux-thunk.d.ts#75249b97104d00c1ca2451ac29369009a5f2b101",
+    "xml2js": "github:DefinitelyTyped/DefinitelyTyped/xml2js/xml2js.d.ts#7304e0770d53762f89af7fcf14517d5f45a04cc2"
   }
 }


### PR DESCRIPTION
Updated parser version and added typings that are no longer published with the parser.

This connects to https://github.com/NYPL-Simplified/opds-feed-parser/issues/29