### PR TITLE
Preserve raw entry info in book data.

### DIFF
--- a/packages/opds-browser/package.json
+++ b/packages/opds-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-browser",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "OPDS browser",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-browser/src/OPDSDataAdapter.ts
+++ b/packages/opds-browser/src/OPDSDataAdapter.ts
@@ -53,7 +53,8 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     publisher: entry.publisher,
     published: formatDate(entry.published),
     categories: categories,
-    url: detailUrl
+    url: detailUrl,
+    rawEntry: entry
   };
 }
 

--- a/packages/opds-browser/src/__tests__/OPDSDataAdaptor-test.ts
+++ b/packages/opds-browser/src/__tests__/OPDSDataAdaptor-test.ts
@@ -55,6 +55,7 @@ describe("OPDSDataAdapter", () => {
     expect(book.imageUrl).toEqual(thumbImageLink.href);
     expect(book.publisher).toBe("Fake Publisher");
     expect(book.published).toBe("June 8, 2014");
+    expect(book.rawEntry).toBe(entry);
   });
 
   it("extracts link info", () => {

--- a/packages/opds-browser/src/interfaces.d.ts
+++ b/packages/opds-browser/src/interfaces.d.ts
@@ -25,6 +25,7 @@ interface BookData {
   publisher?: string;
   published?: string;
   categories?: string[];
+  rawEntry?: any;
 }
 
 interface BookProps extends BookActionProps, BaseProps {


### PR DESCRIPTION
The BookDetailsContainer may need additional info from the parsed OPDS that the main browser doesn't care about.