### PR TITLE
search doesn't fetch description unless url changes

### DIFF
--- a/packages/opds-browser/src/components/Search.tsx
+++ b/packages/opds-browser/src/components/Search.tsx
@@ -27,7 +27,7 @@ export default class Search extends React.Component<SearchProps, any> {
   }
 
   componentWillUpdate(props) {
-    if (props.url) {
+    if (props.url && props.url !== this.props.url) {
       props.fetchSearchDescription(props.url);
     }
   }

--- a/packages/opds-browser/src/components/__tests__/Search-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Search-test.tsx
@@ -17,6 +17,26 @@ describe("Search", () => {
     expect(fetchSearchDescription.mock.calls[0][0]).toEqual("test url");
   });
 
+  it("does not fetch the search description again if url doesn't change", () => {
+    let fetchSearchDescription = jest.genMockFunction();
+    let url = "test url";
+    let searchData = {
+      description: "description",
+      shortName: "shortName",
+      template: (s) => s
+    };
+    let element = document.createElement("div");
+    ReactDOM.render(
+      <Search url={url} fetchSearchDescription={fetchSearchDescription} />,
+      element
+    );
+    ReactDOM.render(
+      <Search url={url} searchData={searchData} fetchSearchDescription={fetchSearchDescription} />,
+      element
+    );
+    expect(fetchSearchDescription.mock.calls.length).toEqual(1);
+  });
+
   it("shows the search form with bootstrap classes", () => {
     let searchData = {
       description: "description",


### PR DESCRIPTION
This branch fixes a bug where the Search component fetches a search description on mount and then receipt of the search description data triggers it to fetch again.