### PR TITLE
Refresh

### DIFF
--- a/packages/opds-browser/src/components/Root.tsx
+++ b/packages/opds-browser/src/components/Root.tsx
@@ -141,7 +141,7 @@ export class Root extends React.Component<RootProps, any> {
                   <BookDetailsContainer
                     bookUrl={this.props.bookUrl}
                     collectionUrl={this.props.collectionUrl}
-                    refreshBrowser={this.props.refresh}>
+                    refreshBrowser={this.props.refreshCollectionAndBook}>
                     <BookDetails book={this.props.bookData} />
                   </BookDetailsContainer> :
                   <div style={{ padding: "40px", maxWidth: "700px", margin: "0 auto" }}>

--- a/packages/opds-browser/src/components/Root.tsx
+++ b/packages/opds-browser/src/components/Root.tsx
@@ -139,8 +139,9 @@ export class Root extends React.Component<RootProps, any> {
               { showBook &&
                 ( BookDetailsContainer ?
                   <BookDetailsContainer
-                    book={this.props.bookData}
-                    collection={this.props.collectionUrl}>
+                    bookUrl={this.props.bookUrl}
+                    collectionUrl={this.props.collectionUrl}
+                    refreshBrowser={this.props.refresh}>
                     <BookDetails book={this.props.bookData} />
                   </BookDetailsContainer> :
                   <div style={{ padding: "40px", maxWidth: "700px", margin: "0 auto" }}>

--- a/packages/opds-browser/src/components/__tests__/OPDSBrowser-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/OPDSBrowser-test.tsx
@@ -29,7 +29,7 @@ describe("OPDSBrowser", () => {
     bookUrl: "book url",
     proxyUrl: "proxy url",
     navigate: jest.genMockFunction(),
-    pathFor: function(collectionUrl: string, bookUrl: string): string { return "path"; },
+    pathFor: (collectionUrl: string, bookUrl: string): string => { return "path"; },
     BookDetailsContainer: TestContainer,
     bookData: {
       id: "book id",

--- a/packages/opds-browser/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Root-test.tsx
@@ -189,7 +189,7 @@ describe("Root", () => {
     expect(breadcrumbs.props.history).toEqual(history);
   });
 
-  it("shows book detail container from config", () => {
+  it("uses book details container from config", () => {
     class Container extends React.Component<BookDetailsContainerProps, any> {
       render(): JSX.Element {
         return (
@@ -201,11 +201,23 @@ describe("Root", () => {
     }
 
     let bookData = groupedCollectionData.lanes[0].books[0];
+    let refresh = jest.genMockFunction();
     let root = TestUtils.renderIntoDocument(
-      <Root bookData={bookData} BookDetailsContainer={Container} />
+      <Root
+        bookData={bookData}
+        bookUrl={bookData.url}
+        collectionUrl="test collection"
+        refreshCollectionAndBook={refresh}
+        setCollectionAndBook={jest.genMockFunction()}
+        BookDetailsContainer={Container} />
     );
-    let container = TestUtils.findRenderedDOMComponentWithClass(root, "container");
-    expect(container.textContent).toContain(bookData.title);
+    let container = TestUtils.findRenderedComponentWithType(root, Container);
+    let element = TestUtils.findRenderedDOMComponentWithClass(root, "container");
+    container.props.refreshBrowser();
+    expect(container.props.bookUrl).toBe(bookData.url);
+    expect(container.props.collectionUrl).toBe("test collection");
+    expect(refresh.mock.calls.length).toBe(1);
+    expect(element.textContent).toContain(bookData.title);
   });
 
   it("sets page title after updating", () => {

--- a/packages/opds-browser/src/components/__tests__/mergeRootProps-test.ts
+++ b/packages/opds-browser/src/components/__tests__/mergeRootProps-test.ts
@@ -265,4 +265,30 @@ describe("mergeRootProps", () => {
       }).catch(err => done.fail(err));
     });
   });
+
+  describe("refresh", () => {
+    let props;
+
+    beforeEach(() => {
+      stateProps = {
+        loadedCollectionUrl: "test collection",
+        loadedBookUrl: "test book"
+      };
+      props = mergeRootProps(stateProps, dispatchProps, componentProps);
+    });
+
+    it("calls fetchCollection", () => {
+      props.refreshCollectionAndBook();
+      expect(fetchCollection.mock.calls.length).toBe(1);
+      expect(fetchCollection.mock.calls[0][0]).toBe("test collection");
+    });
+
+    it("calls fetchBook", (done) => {
+      props.refreshCollectionAndBook().then(data => {
+        expect(fetchBook.mock.calls.length).toBe(1);
+        expect(fetchBook.mock.calls[0][0]).toBe("test book");
+        done();
+      });
+    });
+  });
 });

--- a/packages/opds-browser/src/components/mergeRootProps.ts
+++ b/packages/opds-browser/src/components/mergeRootProps.ts
@@ -23,7 +23,8 @@ export function mapStateToProps(state, ownProps) {
     bookData: state.browser.book.data || ownProps.bookData,
     history: state.browser.collection.history,
     pathFor: ownProps.pathFor || ((collectionUrl: string, bookUrl: string) => "#"),
-    loadedCollectionUrl: state.browser.collection.url
+    loadedCollectionUrl: state.browser.collection.url,
+    loadedBookUrl: state.browser.book.url
   };
 };
 
@@ -32,7 +33,7 @@ export function mapDispatchToProps(dispatch) {
     createDispatchProps: (fetcher) => {
       let actions = new ActionsCreator(fetcher);
       return {
-        fetchCollection: (url: string, isTopLevel) => dispatch(actions.fetchCollection(url, isTopLevel)),
+        fetchCollection: (url: string, isTopLevel?: boolean) => dispatch(actions.fetchCollection(url, isTopLevel)),
         fetchPage: (url: string) => dispatch(actions.fetchPage(url)),
         fetchBook: (url: string) => dispatch(actions.fetchBook(url)),
         loadBook: (book: BookData, url: string) => dispatch(actions.loadBook(book, url)),
@@ -102,13 +103,18 @@ export function mergeRootProps(stateProps, createDispatchProps, componentProps) 
   return Object.assign({}, componentProps, stateProps, dispatchProps, {
     setCollection: setCollection,
     setBook: setBook,
-    setCollectionAndBook: (collectionUrl: string, book: string, isTopLevel: boolean = false) => {
+    setCollectionAndBook: (collectionUrl: string, bookUrl: string, isTopLevel: boolean = false) => {
       return new Promise((resolve, reject) => {
         setCollection(collectionUrl, isTopLevel).then((collectionData: CollectionData) => {
-          setBook(book, collectionData).then((bookData: BookData) => {
+          setBook(bookUrl, collectionData).then((bookData: BookData) => {
             resolve({ collectionData, bookData });
           }).catch(err => reject(err));
         }).catch(err => reject(err));
+      });
+    },
+    refresh: () => {
+      dispatchProps.fetchCollection(stateProps.loadedCollectionUrl).then(data => {
+        dispatchProps.fetchBook(stateProps.loadedBookUrl);
       });
     },
     refreshBook: refreshBook,

--- a/packages/opds-browser/src/components/mergeRootProps.ts
+++ b/packages/opds-browser/src/components/mergeRootProps.ts
@@ -112,12 +112,15 @@ export function mergeRootProps(stateProps, createDispatchProps, componentProps) 
         }).catch(err => reject(err));
       });
     },
-    refresh: () => {
-      dispatchProps.fetchCollection(stateProps.loadedCollectionUrl).then(data => {
-        dispatchProps.fetchBook(stateProps.loadedBookUrl);
+    refreshCollectionAndBook: () => {
+      return new Promise((resolve, reject) => {
+        dispatchProps.fetchCollection(stateProps.loadedCollectionUrl).then(collectionData => {
+          dispatchProps.fetchBook(stateProps.loadedBookUrl).then(bookData => {
+            resolve({ collectionData, bookData });
+          }).catch(err => reject(err));
+        }).catch(err => reject(err));
       });
     },
-    refreshBook: refreshBook,
     clearCollection: () => {
       setCollection(null);
     },

--- a/packages/opds-browser/src/interfaces.d.ts
+++ b/packages/opds-browser/src/interfaces.d.ts
@@ -32,8 +32,10 @@ interface BookProps extends BookActionProps, BaseProps {
   book: BookData;
 }
 
-interface BookDetailsContainerProps extends BookProps {
-  collection: string;
+interface BookDetailsContainerProps extends BaseProps {
+  bookUrl: string;
+  collectionUrl: string;
+  refreshBrowser: () => void;
 }
 
 interface LaneData {
@@ -127,7 +129,8 @@ interface RootProps extends State, CollectionActionProps, BaseProps {
   clearBook?: () => void;
   fetchSearchDescription?: (url: string) => void;
   closeError?: () => void;
-  fetchBook?: (bookUrl: string) => void;
+  fetchBook?: (bookUrl: string) => Promise<any>;
+  refresh: () => void;
   pageTitleTemplate?: (collectionTitle: string, bookTitle: string) => string;
   headerTitle?: string;
   header?: new () => __React.Component<HeaderProps, any>;

--- a/packages/opds-browser/src/interfaces.d.ts
+++ b/packages/opds-browser/src/interfaces.d.ts
@@ -130,7 +130,7 @@ interface RootProps extends State, CollectionActionProps, BaseProps {
   fetchSearchDescription?: (url: string) => void;
   closeError?: () => void;
   fetchBook?: (bookUrl: string) => Promise<any>;
-  refresh: () => void;
+  refreshCollectionAndBook?: () => void;
   pageTitleTemplate?: (collectionTitle: string, bookTitle: string) => string;
   headerTitle?: string;
   header?: new () => __React.Component<HeaderProps, any>;


### PR DESCRIPTION
Recent changes to navigation removed top-level refs and functions but didn't provide a way for BookDetailsContainer to refresh data in the browser, because calling navigate with the existing book and collection url doesn't update data.

This branch resolves this issue by adding a refreshCollectionAndBook() prop to Root, which passes it directly to BookDetailsContainer.