### PR TITLE
Don't try to parse published date if it's undefined.

### DIFF
--- a/packages/opds-browser/src/OPDSDataAdapter.ts
+++ b/packages/opds-browser/src/OPDSDataAdapter.ts
@@ -63,7 +63,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     summary: sanitizeHtml(entry.summary.content),
     imageUrl: imageUrl,
     publisher: entry.publisher,
-    published: formatDate(entry.published),
+    published: entry.published && formatDate(entry.published),
     categories: categories,
     url: detailUrl
   };


### PR DESCRIPTION
This fixes a bug where the browser would show "Published: undefined NaN, NaN" for OPDS entries without a published date.