### PR TITLE
interfaces always explicitly imported

### DIFF
--- a/packages/opds-browser/package.json
+++ b/packages/opds-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-browser",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "OPDS browser",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-browser/src/OPDSDataAdapter.ts
+++ b/packages/opds-browser/src/OPDSDataAdapter.ts
@@ -10,6 +10,14 @@ import {
   OPDSCatalogRootLink
 } from "opds-feed-parser";
 import * as url from "url";
+import {
+  CollectionData,
+  LaneData,
+  BookData,
+  LinkData,
+  FacetGroupData,
+  SearchData
+} from "./interfaces";
 const sanitizeHtml = require("dompurify").sanitize;
 
 export function adapter(data: OPDSFeed|OPDSEntry, url: string): CollectionData|BookData {

--- a/packages/opds-browser/src/OpenSearchDescriptionParser.ts
+++ b/packages/opds-browser/src/OpenSearchDescriptionParser.ts
@@ -1,3 +1,4 @@
+import { SearchData } from "./interfaces";
 import * as xml2js from "xml2js";
 import * as url from "url";
 

--- a/packages/opds-browser/src/actions.ts
+++ b/packages/opds-browser/src/actions.ts
@@ -1,4 +1,5 @@
 import DataFetcher from "./DataFetcher";
+import { CollectionData, BookData, SearchData, FetchError } from "./interfaces";
 
 export default class ActionCreator {
   private fetcher: DataFetcher;

--- a/packages/opds-browser/src/actions.ts
+++ b/packages/opds-browser/src/actions.ts
@@ -1,5 +1,5 @@
 import DataFetcher from "./DataFetcher";
-import { CollectionData, BookData, SearchData, FetchError } from "./interfaces";
+import { CollectionData, BookData, SearchData, FetchErrorData } from "./interfaces";
 
 export default class ActionCreator {
   private fetcher: DataFetcher;
@@ -95,7 +95,7 @@ export default class ActionCreator {
     return { type: this.FETCH_COLLECTION_SUCCESS };
   }
 
-  fetchCollectionFailure(error?: FetchError) {
+  fetchCollectionFailure(error?: FetchErrorData) {
     return { type: this.FETCH_COLLECTION_FAILURE, error };
   }
 
@@ -111,7 +111,7 @@ export default class ActionCreator {
     return { type: this.FETCH_PAGE_SUCCESS };
   }
 
-  fetchPageFailure(error?: FetchError) {
+  fetchPageFailure(error?: FetchErrorData) {
     return { type: this.FETCH_PAGE_FAILURE, error };
   }
 
@@ -139,7 +139,7 @@ export default class ActionCreator {
     return { type: this.FETCH_BOOK_SUCCESS };
   }
 
-  fetchBookFailure(error?: FetchError) {
+  fetchBookFailure(error?: FetchErrorData) {
     return { type: this.FETCH_BOOK_FAILURE, error };
   }
 

--- a/packages/opds-browser/src/components/Book.tsx
+++ b/packages/opds-browser/src/components/Book.tsx
@@ -65,6 +65,6 @@ export default class Book extends React.Component<BookProps, any> {
           </div>
         </BookPreviewLink>
       </div>
-    ) as React.ComponentElement<any, Book>;
+    );
   }
 }

--- a/packages/opds-browser/src/components/Book.tsx
+++ b/packages/opds-browser/src/components/Book.tsx
@@ -1,8 +1,12 @@
 import * as React from "react";
 import BookPreviewLink from "./BookPreviewLink";
+import { BookData, Navigate, PathFor } from "../interfaces";
 
-export interface BookProps extends BookActionProps, BaseProps {
+export interface BookProps {
   book: BookData;
+  navigate?: Navigate;
+  pathFor?: PathFor;
+  collectionUrl?: string;
 }
 
 export default class Book extends React.Component<BookProps, any> {

--- a/packages/opds-browser/src/components/Book.tsx
+++ b/packages/opds-browser/src/components/Book.tsx
@@ -65,6 +65,6 @@ export default class Book extends React.Component<BookProps, any> {
           </div>
         </BookPreviewLink>
       </div>
-    );
+    ) as React.ComponentElement<any, Book>;
   }
 }

--- a/packages/opds-browser/src/components/BookPreviewLink.tsx
+++ b/packages/opds-browser/src/components/BookPreviewLink.tsx
@@ -1,8 +1,12 @@
 import * as React from "react";
 import Link, { LinkProps } from "./Link";
+import { BookData, Navigate, PathFor } from "../interfaces";
 
-export interface BookPreviewLinkProps extends LinkProps, BookActionProps, BaseProps {
+export interface BookPreviewLinkProps extends LinkProps {
   book?: BookData;
+  navigate: Navigate;
+  pathFor: PathFor;
+  collectionUrl: string;
 }
 
 export default class BookPreviewLink extends Link<BookPreviewLinkProps> {

--- a/packages/opds-browser/src/components/Breadcrumbs.tsx
+++ b/packages/opds-browser/src/components/Breadcrumbs.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import CollectionLink from "./CollectionLink";
+import { CollectionData, LinkData, Navigate, PathFor } from "../interfaces";
 import { subtleListStyle } from "./styles";
 
-export interface BreadcrumbsProps extends BaseProps, CollectionActionProps {
+export interface BreadcrumbsProps {
   history: LinkData[];
   collection: CollectionData;
   showCurrentLink?: Boolean;
+  navigate?: Navigate;
+  pathFor?: PathFor;
 }
 
 export default class Breadcrumbs extends React.Component<BreadcrumbsProps, any> {

--- a/packages/opds-browser/src/components/Collection.tsx
+++ b/packages/opds-browser/src/components/Collection.tsx
@@ -5,14 +5,14 @@ import Lane from "./Lane";
 import FacetGroup from "./FacetGroup";
 import Search from "./Search";
 import SkipNavigationLink from "./SkipNavigationLink";
-import { CollectionData, LinkData, Navigate, PathFor, FetchError } from "../interfaces";
+import { CollectionData, LinkData, Navigate, PathFor, FetchErrorData } from "../interfaces";
 import { visuallyHiddenStyle, subtleListStyle } from "./styles";
 
 export interface CollectionProps extends React.HTMLProps<Collection> {
   collection: CollectionData;
   isFetching?: boolean;
   isFetchingPage?: boolean;
-  error?: FetchError;
+  error?: FetchErrorData;
   fetchSearchDescription?: (url: string) => void;
   history?: LinkData[];
   navigate?: Navigate;

--- a/packages/opds-browser/src/components/Collection.tsx
+++ b/packages/opds-browser/src/components/Collection.tsx
@@ -5,15 +5,19 @@ import Lane from "./Lane";
 import FacetGroup from "./FacetGroup";
 import Search from "./Search";
 import SkipNavigationLink from "./SkipNavigationLink";
+import { CollectionData, LinkData, Navigate, PathFor, FetchError } from "../interfaces";
 import { visuallyHiddenStyle, subtleListStyle } from "./styles";
 
-export interface CollectionProps extends CollectionActionProps, BookActionProps, BaseProps {
+export interface CollectionProps extends React.HTMLProps<Collection> {
   collection: CollectionData;
   isFetching?: boolean;
   isFetchingPage?: boolean;
   error?: FetchError;
   fetchSearchDescription?: (url: string) => void;
   history?: LinkData[];
+  navigate?: Navigate;
+  pathFor?: PathFor;
+  fetchPage?: (url: string) => Promise<any>;
 }
 
 export default class Collection extends React.Component<CollectionProps, any> {

--- a/packages/opds-browser/src/components/CollectionLink.tsx
+++ b/packages/opds-browser/src/components/CollectionLink.tsx
@@ -1,12 +1,18 @@
 import * as React from "react";
 import Link, { LinkProps} from "./Link";
+import { Navigate, PathFor } from "../interfaces";
 
-export interface CollectionLinkProps extends LinkProps, CollectionActionProps {
+export interface CollectionLinkProps extends LinkProps {
+  navigate?: Navigate;
+  pathFor?: PathFor;
+  isTopLevel?: boolean;
 }
 
 export default class CollectionLink extends Link<CollectionLinkProps> {
   processClick() {
-    this.props.navigate(this.props.url, null, this.props.isTopLevel);
+    if (this.props.navigate) {
+      this.props.navigate(this.props.url, null, this.props.isTopLevel);
+    }
   }
 
   href() {

--- a/packages/opds-browser/src/components/FacetGroup.tsx
+++ b/packages/opds-browser/src/components/FacetGroup.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
 import CollectionLink from "./CollectionLink";
+import { FacetGroupData, Navigate, PathFor } from "../interfaces";
 import { subtleListStyle } from "./styles";
 
-export interface FacetGroupProps extends CollectionActionProps, BaseProps {
+export interface FacetGroupProps {
   facetGroup: FacetGroupData;
+  navigate?: Navigate;
+  pathFor?: PathFor;
 }
 
 export default class FacetGroup extends React.Component<FacetGroupProps, any> {

--- a/packages/opds-browser/src/components/Lane.tsx
+++ b/packages/opds-browser/src/components/Lane.tsx
@@ -1,9 +1,13 @@
 import * as React from "react";
 import LaneBook from "./LaneBook";
 import CollectionLink from "./CollectionLink";
+import { LaneData, Navigate, PathFor } from "../interfaces";
 
-export interface LaneProps extends CollectionActionProps, BookActionProps, BaseProps {
+export interface LaneProps {
   lane: LaneData;
+  navigate?: Navigate;
+  pathFor?: PathFor;
+  collectionUrl?: string;
 }
 
 export default class Lane extends React.Component<LaneProps, any> {

--- a/packages/opds-browser/src/components/Link.tsx
+++ b/packages/opds-browser/src/components/Link.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export interface LinkProps extends BaseProps {
+export interface LinkProps extends React.HTMLProps<any> {
   text?: string; // optional because link can have child elements instead of text
   url: string;
 }

--- a/packages/opds-browser/src/components/Root.tsx
+++ b/packages/opds-browser/src/components/Root.tsx
@@ -12,18 +12,19 @@ import UrlForm from "./UrlForm";
 import SkipNavigationLink from "./SkipNavigationLink";
 import CollectionLink from "./CollectionLink";
 import HeaderCollectionLink from "./HeaderCollectionLink";
+import { State, Navigate, PathFor } from "../interfaces";
 
-export interface HeaderProps extends BaseProps {
+export interface HeaderProps extends React.Props<any> {
   CollectionLink: typeof HeaderCollectionLink;
 }
 
-export interface BookDetailsContainerProps extends BaseProps {
+export interface BookDetailsContainerProps extends React.Props<any> {
   bookUrl: string;
   collectionUrl: string;
   refreshBrowser: () => void;
 }
 
-export interface RootProps extends State, CollectionActionProps, BaseProps {
+export interface RootProps extends State {
   store?: Redux.Store;
   collectionUrl?: string;
   bookUrl?: string;
@@ -41,6 +42,10 @@ export interface RootProps extends State, CollectionActionProps, BaseProps {
   pageTitleTemplate?: (collectionTitle: string, bookTitle: string) => string;
   headerTitle?: string;
   header?: new () => __React.Component<HeaderProps, any>;
+  navigate?: Navigate;
+  pathFor?: PathFor;
+  fetchPage?: (url: string) => Promise<any>;
+  isTopLevel?: boolean;
 }
 
 export class Root extends React.Component<RootProps, any> {
@@ -204,7 +209,7 @@ export class Root extends React.Component<RootProps, any> {
     document.addEventListener("keydown", this.handleKeyDown.bind(this));
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: RootProps) {
     if (nextProps.collectionUrl !== this.props.collectionUrl || nextProps.bookUrl !== this.props.bookUrl) {
       this.props.setCollectionAndBook(nextProps.collectionUrl, nextProps.bookUrl, nextProps.isTopLevel);
     }

--- a/packages/opds-browser/src/components/Root.tsx
+++ b/packages/opds-browser/src/components/Root.tsx
@@ -21,7 +21,7 @@ export interface HeaderProps extends React.Props<any> {
 export interface BookDetailsContainerProps extends React.Props<any> {
   bookUrl: string;
   collectionUrl: string;
-  refreshBrowser: () => void;
+  refreshBrowser: () => Promise<any>;
 }
 
 export interface RootProps extends State {

--- a/packages/opds-browser/src/components/Search.tsx
+++ b/packages/opds-browser/src/components/Search.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
+import { SearchData, Navigate } from "../interfaces";
 
-export interface SearchProps extends SearchData {
+export interface SearchProps extends SearchData, React.HTMLProps<Search> {
   fetchSearchDescription?: (url: string) => void;
+  navigate: Navigate;
+  isTopLevel?: boolean;
 }
 
 export default class Search extends React.Component<SearchProps, any> {

--- a/packages/opds-browser/src/components/UrlForm.tsx
+++ b/packages/opds-browser/src/components/UrlForm.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
+import { Navigate } from "../interfaces";
 
-export interface UrlFormProps extends CollectionActionProps, BaseProps {
+export interface UrlFormProps {
   url?: string;
+  navigate: Navigate;
 }
 
 export default class UrlForm extends React.Component<UrlFormProps, any> {

--- a/packages/opds-browser/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Book-test.tsx
@@ -22,7 +22,7 @@ describe("Book", () => {
   it("shows the book cover with empty alt", () => {
     let renderedBook = TestUtils.renderIntoDocument(
       <Book book={book} />
-    );
+    ) as Book;
 
     let coverImage = TestUtils.findRenderedDOMComponentWithTag(renderedBook, "img");
     expect(coverImage.getAttribute("src")).toEqual(book.imageUrl);
@@ -33,7 +33,7 @@ describe("Book", () => {
   it("shows book info", () => {
     let renderedBook = TestUtils.renderIntoDocument(
       <Book book={book} />
-    );
+    ) as Book;
 
     let title = TestUtils.findRenderedDOMComponentWithClass(renderedBook, "bookTitle");
     expect(title.textContent).toEqual(book.title);
@@ -49,7 +49,7 @@ describe("Book", () => {
     });
     let renderedBook = TestUtils.renderIntoDocument(
       <Book book={bookCopy} />
-    );
+    ) as Book;
 
     let authors = TestUtils.findRenderedDOMComponentWithClass(renderedBook, "bookAuthors");
     expect(authors.textContent).toEqual(bookCopy.contributors[0]);

--- a/packages/opds-browser/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Book-test.tsx
@@ -7,6 +7,7 @@ import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-addons-test-utils";
 
 import Book from "../Book";
+import { BookData } from "../../interfaces";
 
 let book: BookData = {
   id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",

--- a/packages/opds-browser/src/components/__tests__/BookPreviewLink-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/BookPreviewLink-test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-addons-test-utils";
 
-import BookPreviewLink, { BookPreviewLinkProps } from "../BookPreviewLink";
+import BookPreviewLink from "../BookPreviewLink";
 
 let book = {
   id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
@@ -17,7 +17,7 @@ let book = {
   publisher: "Penguin Publishing Group"
 };
 
-let linkProps: BookPreviewLinkProps = {
+let linkProps = {
   text: "test text",
   url: "http://circulation.librarysimplified.org/works/3M/crrmnr9",
   collectionUrl: "http://example.com/feed",

--- a/packages/opds-browser/src/components/__tests__/Breadcrumbs-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Breadcrumbs-test.tsx
@@ -9,6 +9,7 @@ import * as TestUtils from "react-addons-test-utils";
 import Breadcrumbs from "../Breadcrumbs";
 import CollectionLink from "../CollectionLink";
 import { ungroupedCollectionData } from "./collectionData";
+import { LinkData } from "../../interfaces";
 
 describe("Breadcrumbs", () => {
   let history: LinkData[];

--- a/packages/opds-browser/src/components/__tests__/Breadcrumbs-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Breadcrumbs-test.tsx
@@ -30,7 +30,7 @@ describe("Breadcrumbs", () => {
   it("shows breadcrumbs with bootstrap classes", () => {
     let breadcrumbs = TestUtils.renderIntoDocument(
       <Breadcrumbs collection={collectionData} history={history} />
-    );
+    ) as Breadcrumbs;
 
     let list = TestUtils.findRenderedDOMComponentWithTag(breadcrumbs, "ol");
     let links = TestUtils.scryRenderedComponentsWithType(breadcrumbs, CollectionLink);
@@ -51,7 +51,7 @@ describe("Breadcrumbs", () => {
         history={history}
         pathFor={pathFor}
         showCurrentLink={true} />
-    );
+    ) as Breadcrumbs;
 
     let currentLink = TestUtils.findRenderedDOMComponentWithClass(breadcrumbs, "currentCollectionLink");
     expect(currentLink.textContent).toBe(collectionData.title);

--- a/packages/opds-browser/src/components/__tests__/Collection-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Collection-test.tsx
@@ -19,6 +19,7 @@ import FacetGroup from "../FacetGroup";
 import CollectionLink from "../CollectionLink";
 import SkipNavigationLink from "../SkipNavigationLink";
 import { groupedCollectionData, ungroupedCollectionData } from "./collectionData";
+import { CollectionData } from "../../interfaces";
 
 describe("Collection", () => {
   describe("collection with lanes", () => {
@@ -51,7 +52,7 @@ describe("Collection", () => {
 
     it("shows lanes in order", () => {
       let lanes = TestUtils.scryRenderedComponentsWithType(collection, Lane);
-      let laneTitles = lanes.map(lane => lane.props.title);
+      let laneTitles = lanes.map(lane => lane.props.lane.title);
       expect(laneTitles).toEqual(collectionData.lanes.map(lane => lane.title));
     });
   });
@@ -88,7 +89,7 @@ describe("Collection", () => {
         <Collection collection={collectionData} />
       );
       let books: Book[] = TestUtils.scryRenderedComponentsWithType(collection, Book);
-      let bookTitles = books.map(book => book.props.title);
+      let bookTitles = books.map(book => book.props.book.title);
       expect(bookTitles).toEqual(collectionData.books.map(book => book.title));
     });
   });

--- a/packages/opds-browser/src/components/__tests__/Collection-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Collection-test.tsx
@@ -29,7 +29,7 @@ describe("Collection", () => {
     beforeEach(() => {
       collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} />
-      );
+      ) as Collection;
     });
 
     it("contains #main anchor", () => {
@@ -64,7 +64,7 @@ describe("Collection", () => {
     beforeEach(() => {
       collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} />
-      );
+      ) as Collection;
     });
 
     it("shows #main anchor", () => {
@@ -75,7 +75,7 @@ describe("Collection", () => {
     it("shows books", () => {
       let collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} />
-      );
+      ) as Collection;
       let books: LaneBook[] = TestUtils.scryRenderedComponentsWithType(collection, LaneBook);
       // count books in all lanes plus books directly belonging to this collection
       let bookCount = collectionData.lanes.reduce((count, lane) => {
@@ -87,7 +87,7 @@ describe("Collection", () => {
     it("shows books in order", () => {
       let collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} />
-      );
+      ) as Collection;
       let books: Book[] = TestUtils.scryRenderedComponentsWithType(collection, Book);
       let bookTitles = books.map(book => book.props.book.title);
       expect(bookTitles).toEqual(collectionData.books.map(book => book.title));
@@ -113,7 +113,7 @@ describe("Collection", () => {
 
       collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} />
-      );
+      ) as Collection;
     });
 
     it("shows facet groups", () => {
@@ -143,7 +143,7 @@ describe("Collection", () => {
 
       let collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} fetchPage={fetchPage} />
-      );
+      ) as Collection;
 
       document.body.scrollTop = 1000;
       document.body.scrollHeight = 1;
@@ -180,7 +180,7 @@ describe("Collection", () => {
 
       let collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} fetchPage={fetchPage} />
-      );
+      ) as Collection;
 
       expect(fetchPage.mock.calls.length).toEqual(1);
       expect(fetchPage.mock.calls[0][0]).toEqual("next");
@@ -198,7 +198,7 @@ describe("Collection", () => {
 
       let collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} isFetchingPage={true} />
-      );
+      ) as Collection;
 
       let loading = TestUtils.findRenderedDOMComponentWithClass(collection, "loadingNextPage");
       expect(loading.textContent).toContain("Loading");
@@ -211,7 +211,7 @@ describe("Collection", () => {
       });
       let collection = TestUtils.renderIntoDocument(
         <Collection collection={collectionData} isFetchingPage={false} fetchPage={fetchPage} />
-      );
+      ) as Collection;
 
       let link = TestUtils.findRenderedDOMComponentWithClass(collection, "nextPageLink");
       expect(link.textContent).toBe("Load more books");

--- a/packages/opds-browser/src/components/__tests__/ErrorMessage-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/ErrorMessage-test.tsx
@@ -10,7 +10,7 @@ describe("ErrorMessage", () => {
   it("shows the message", () => {
     let error = TestUtils.renderIntoDocument(
       <ErrorMessage message="test error" />
-    );
+    ) as ErrorMessage;
 
     let element = ReactDOM.findDOMNode(error);
     expect(element.textContent).toContain("test error");
@@ -19,7 +19,7 @@ describe("ErrorMessage", () => {
   it("goes back", () => {
     let error = TestUtils.renderIntoDocument(
       <ErrorMessage message="test error" />
-    );
+    ) as ErrorMessage;
 
     let button = TestUtils.findRenderedDOMComponentWithClass(error, "errorCloseButton");
     spyOn(window.history, "back");
@@ -32,7 +32,7 @@ describe("ErrorMessage", () => {
     let retry = jest.genMockFunction();
     let error = TestUtils.renderIntoDocument(
       <ErrorMessage message="test error" retry={retry} />
-    );
+    ) as ErrorMessage;
 
     let button = TestUtils.findRenderedDOMComponentWithClass(error, "retryButton");
     TestUtils.Simulate.click(button);
@@ -43,7 +43,7 @@ describe("ErrorMessage", () => {
   it("uses bootstrap classes", () => {
     let error = TestUtils.renderIntoDocument(
       <ErrorMessage message="test error" />
-    );
+    ) as ErrorMessage;
 
     let buttons = TestUtils.scryRenderedDOMComponentsWithClass(error, "btn");
     expect(buttons.length).toBe(2);

--- a/packages/opds-browser/src/components/__tests__/FacetGroup-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/FacetGroup-test.tsx
@@ -9,6 +9,7 @@ import * as TestUtils from "react-addons-test-utils";
 
 import FacetGroup from "../FacetGroup";
 import SkipNavigationLink from "../SkipNavigationLink";
+import { FacetGroupData } from "../../interfaces";
 
 describe("FacetGroup", () => {
   it("shows facet group label", () => {

--- a/packages/opds-browser/src/components/__tests__/FacetGroup-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/FacetGroup-test.tsx
@@ -20,7 +20,7 @@ describe("FacetGroup", () => {
 
     let renderedFacetGroup = TestUtils.renderIntoDocument(
       <FacetGroup facetGroup={facetGroup} />
-    );
+    ) as FacetGroup;
 
     let label = TestUtils.findRenderedDOMComponentWithClass(renderedFacetGroup, "facet-group-label");
     expect(label.textContent).toEqual(facetGroup.label + ":");
@@ -45,7 +45,7 @@ describe("FacetGroup", () => {
 
     let renderedFacetGroup = TestUtils.renderIntoDocument(
       <FacetGroup facetGroup={facetGroup} />
-    );
+    ) as FacetGroup;
 
     let facets = TestUtils.scryRenderedDOMComponentsWithClass(renderedFacetGroup, "facetLink");
     expect(facets.length).toEqual(2);

--- a/packages/opds-browser/src/components/__tests__/Lane-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Lane-test.tsx
@@ -32,7 +32,7 @@ describe("Lane", () => {
   it("shows the lane title", () => {
     let lane = TestUtils.renderIntoDocument(
       <Lane lane={laneData} />
-    );
+    ) as Lane;
 
     let titleLink = TestUtils.findRenderedDOMComponentWithClass(lane, "laneTitle");
     expect(titleLink.textContent).toBe(laneData.title);
@@ -41,7 +41,7 @@ describe("Lane", () => {
   it("shows the books", () => {
     let lane = TestUtils.renderIntoDocument(
       <Lane lane={laneData} />
-    );
+    ) as Lane;
 
     let books = TestUtils.scryRenderedComponentsWithType(lane, Book);
     expect(books.length).toBe(books.length);

--- a/packages/opds-browser/src/components/__tests__/Lane-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Lane-test.tsx
@@ -10,6 +10,7 @@ import * as TestUtils from "react-addons-test-utils";
 import Lane from "../Lane";
 import CollectionLink from "../CollectionLink";
 import Book from "../Book";
+import { LaneData, BookData } from "../../interfaces";
 
 let books: BookData[] = [1, 2, 3].map((i) => {
   return {

--- a/packages/opds-browser/src/components/__tests__/LaneBook-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/LaneBook-test.tsx
@@ -23,7 +23,7 @@ describe("LaneBook", () => {
   it("shows the book cover with empty alt", () => {
     let renderedBook = TestUtils.renderIntoDocument(
       <LaneBook book={book} />
-    );
+    ) as LaneBook;
 
     let coverImage = TestUtils.findRenderedDOMComponentWithTag(renderedBook, "img");
     expect(coverImage.getAttribute("src")).toBe(book.imageUrl);
@@ -34,7 +34,7 @@ describe("LaneBook", () => {
   it("shows book title", () => {
     let renderedBook = TestUtils.renderIntoDocument(
       <LaneBook book={book} />
-    );
+    ) as LaneBook;
 
     let title = TestUtils.findRenderedDOMComponentWithClass(renderedBook, "bookTitle");
     expect(title.textContent).toBe(book.title);

--- a/packages/opds-browser/src/components/__tests__/LaneBook-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/LaneBook-test.tsx
@@ -8,6 +8,7 @@ import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-addons-test-utils";
 
 import LaneBook from "../LaneBook";
+import { BookData } from "../../interfaces";
 
 let book: BookData = {
   id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",

--- a/packages/opds-browser/src/components/__tests__/Link-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Link-test.tsx
@@ -27,7 +27,7 @@ describe("Link", () => {
 
     let link = TestUtils.renderIntoDocument(
       <SpecificLink {...linkProps} />
-    );
+    ) as SpecificLink;
 
     let element = TestUtils.findRenderedDOMComponentWithTag(link, "a");
     TestUtils.Simulate.click(element);

--- a/packages/opds-browser/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Root-test.tsx
@@ -15,6 +15,7 @@ import HeaderCollectionLink from "../HeaderCollectionLink";
 import Search from "../Search";
 import { groupedCollectionData, ungroupedCollectionData } from "./collectionData";
 import buildStore from "../../store";
+import { CollectionData, BookData } from "../../interfaces";
 
 describe("Root", () => {
   it("shows skip navigation link", () => {
@@ -44,6 +45,7 @@ describe("Root", () => {
         collectionData={collectionData}
         fetchSearchDescription={(url: string) => {}}
         navigate={navigate}
+        pathFor={jest.genMockFunction()}
         />
     );
     let search = TestUtils.findRenderedComponentWithType(root, Search);
@@ -58,7 +60,11 @@ describe("Root", () => {
   it("shows a collection if props include collectionData", () => {
     let collectionData: CollectionData = groupedCollectionData;
     let root = TestUtils.renderIntoDocument(
-      <Root collectionData={collectionData} />
+      <Root
+        collectionData={collectionData}
+        navigate={jest.genMockFunction()}
+        pathFor={jest.genMockFunction()}
+        />
     );
 
     let collections = TestUtils.scryRenderedComponentsWithType(root, Collection);

--- a/packages/opds-browser/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Root-test.tsx
@@ -21,7 +21,7 @@ describe("Root", () => {
   it("shows skip navigation link", () => {
     let root = TestUtils.renderIntoDocument(
       <Root />
-    );
+    ) as Root;
 
     let link = TestUtils.findRenderedComponentWithType(root, SkipNavigationLink);
     expect(link).toBeTruthy();
@@ -47,7 +47,7 @@ describe("Root", () => {
         navigate={navigate}
         pathFor={jest.genMockFunction()}
         />
-    );
+    ) as Root;
     let search = TestUtils.findRenderedComponentWithType(root, Search);
     let form = TestUtils.findRenderedDOMComponentWithTag(search, "form");
     TestUtils.Simulate.submit(form);
@@ -65,7 +65,7 @@ describe("Root", () => {
         navigate={jest.genMockFunction()}
         pathFor={jest.genMockFunction()}
         />
-    );
+    ) as Root;
 
     let collections = TestUtils.scryRenderedComponentsWithType(root, Collection);
     expect(collections.length).toBe(1);
@@ -75,7 +75,7 @@ describe("Root", () => {
   it("shows a url form if no collection url or book url", () => {
     let root = TestUtils.renderIntoDocument(
       <Root />
-    );
+    ) as Root;
 
     let urlForms = TestUtils.scryRenderedComponentsWithType(root, UrlForm);
     expect(urlForms.length).toBe(1);
@@ -84,7 +84,7 @@ describe("Root", () => {
   it("doesn't show a url form if collection url", () => {
     let root = TestUtils.renderIntoDocument(
       <Root collectionUrl="test" setCollectionAndBook={jest.genMockFunction()} />
-    );
+    ) as Root;
 
     let urlForms = TestUtils.scryRenderedComponentsWithType(root, UrlForm);
     expect(urlForms.length).toBe(0);
@@ -93,7 +93,7 @@ describe("Root", () => {
   it("doesn't show a url form if book url", () => {
     let root = TestUtils.renderIntoDocument(
       <Root bookUrl="test" setCollectionAndBook={jest.genMockFunction()} />
-    );
+    ) as Root;
 
     let urlForms = TestUtils.scryRenderedComponentsWithType(root, UrlForm);
     expect(urlForms.length).toBe(0);
@@ -104,7 +104,7 @@ describe("Root", () => {
     let setCollectionAndBook = jest.genMockFunction();
     let root = TestUtils.renderIntoDocument(
       <Root collectionUrl={collectionUrl} setCollectionAndBook={setCollectionAndBook}/>
-    );
+    ) as Root;
 
     expect(setCollectionAndBook.mock.calls.length).toBe(1);
     expect(setCollectionAndBook.mock.calls[0][0]).toBe(collectionUrl);
@@ -116,7 +116,7 @@ describe("Root", () => {
     let setCollectionAndBook = jest.genMockFunction();
     let root = TestUtils.renderIntoDocument(
       <Root bookUrl={bookUrl} setCollectionAndBook={setCollectionAndBook}/>
-    );
+    ) as Root;
 
     expect(setCollectionAndBook.mock.calls.length).toBe(1);
     expect(setCollectionAndBook.mock.calls[0][0]).toBeFalsy();
@@ -131,11 +131,11 @@ describe("Root", () => {
     let root = ReactDOM.render(
       <Root collectionUrl={collectionUrl} setCollectionAndBook={setCollectionAndBook} />,
       elem
-    );
+    ) as Root;
     ReactDOM.render(
       <Root collectionUrl={newCollection} setCollectionAndBook={setCollectionAndBook} isTopLevel={true} />,
       elem
-    );
+    ) as Root;
 
     expect(setCollectionAndBook.mock.calls.length).toBe(2);
     expect(setCollectionAndBook.mock.calls[1][0]).toBe(newCollection);
@@ -146,7 +146,7 @@ describe("Root", () => {
   it("shows loading message", () => {
     let root = TestUtils.renderIntoDocument(
       <Root isFetching={true}/>
-    );
+    ) as Root;
 
     let loading = TestUtils.findRenderedDOMComponentWithClass(root, "loading");
     expect(loading.textContent).toBeTruthy();
@@ -160,7 +160,7 @@ describe("Root", () => {
     };
     let root = TestUtils.renderIntoDocument(
       <Root error={fetchError}/>
-    );
+    ) as Root;
 
     let error = TestUtils.findRenderedDOMComponentWithClass(root, "error");
     expect(error.textContent).toContain("test error url");
@@ -170,7 +170,7 @@ describe("Root", () => {
     let bookData = groupedCollectionData.lanes[0].books[0];
     let root = TestUtils.renderIntoDocument(
       <Root bookData={bookData}/>
-    );
+    ) as Root;
     let book = TestUtils.findRenderedDOMComponentWithClass(root, "bookDetails");
 
     expect(book.textContent).toContain(bookData.title);
@@ -190,7 +190,7 @@ describe("Root", () => {
 
     let root = TestUtils.renderIntoDocument(
       <Root collectionData={ungroupedCollectionData} history={history} />
-    );
+    ) as Root;
 
     let breadcrumbs = TestUtils.findRenderedComponentWithType(root, Breadcrumbs);
     expect(breadcrumbs.props.history).toEqual(history);
@@ -218,7 +218,7 @@ describe("Root", () => {
           refreshCollectionAndBook={refresh}
           setCollectionAndBook={jest.genMockFunction()}
           BookDetailsContainer={Container} />
-      );
+      ) as Root;
       let container = TestUtils.findRenderedComponentWithType(root, Container);
       let element = TestUtils.findRenderedDOMComponentWithClass(root, "container");
       container.props.refreshBrowser();
@@ -239,7 +239,7 @@ describe("Root", () => {
           refreshCollectionAndBook={refresh}
           setCollectionAndBook={jest.genMockFunction()}
           BookDetailsContainer={Container} />
-      );
+      ) as Root;
       let containers = TestUtils.scryRenderedComponentsWithType(root, Container);
       expect(containers.length).toBe(0);
     });
@@ -259,7 +259,7 @@ describe("Root", () => {
         bookData={bookData}
         pageTitleTemplate={pageTitleTemplate} />,
       elem
-    );
+    ) as Root;
 
     // template should be invoked by componentWillMount
     expect(pageTitleTemplate.mock.calls.length).toBe(1);
@@ -270,7 +270,7 @@ describe("Root", () => {
     ReactDOM.render(
       <Root collectionData={null} bookData={null} pageTitleTemplate={pageTitleTemplate} />,
       elem
-    );
+    ) as Root;
 
     // template should be invoked again by componentWillUpdate
     expect(pageTitleTemplate.mock.calls.length).toBe(2);
@@ -281,13 +281,13 @@ describe("Root", () => {
 
   it("calls showPrevBook() on left key press but not if meta key is also presssed", () => {
     let showPrevBook = jest.genMockFunction();
-    let root = TestUtils.renderIntoDocument<Root>(
+    let root = TestUtils.renderIntoDocument(
       <Root
         bookUrl="test book"
         collectionUrl="test collection"
         setCollectionAndBook={jest.genMockFunction()}
         />
-    );
+    ) as Root;
     root.showPrevBook = showPrevBook;
 
     document.dispatchEvent(new KeyboardEvent("keydown", {
@@ -306,13 +306,13 @@ describe("Root", () => {
 
   it("calls showNextBook() on right key press but not if meta key is also presssed", () => {
     let showNextBook = jest.genMockFunction();
-    let root = TestUtils.renderIntoDocument<Root>(
+    let root = TestUtils.renderIntoDocument(
       <Root
         bookUrl="test book"
         collectionUrl="test collection"
         setCollectionAndBook={jest.genMockFunction()}
         />
-    );
+    ) as Root;
     root.showNextBook = showNextBook;
 
     document.dispatchEvent(new KeyboardEvent("keydown", {
@@ -415,14 +415,14 @@ describe("Root", () => {
     it("navigates to second book if currently showing first book", () => {
       bookData = groupedCollectionData.lanes[0].books[0];
       nextBookData = groupedCollectionData.lanes[0].books[1];
-      root = TestUtils.renderIntoDocument<Root>(
+      root = TestUtils.renderIntoDocument(
         <Root
           navigate={navigate}
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={jest.genMockFunction()}
           />
-      );
+      ) as Root;
       root.showNextBook();
 
       expect(navigate.mock.calls.length).toBe(1);
@@ -434,14 +434,14 @@ describe("Root", () => {
       let lastIndex = groupedCollectionData.lanes[0].books.length - 1;
       bookData = groupedCollectionData.lanes[0].books[lastIndex];
       nextBookData = groupedCollectionData.lanes[0].books[0];
-      root = TestUtils.renderIntoDocument<Root>(
+      root = TestUtils.renderIntoDocument(
         <Root
           navigate={navigate}
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={jest.genMockFunction()}
           />
-      );
+      ) as Root;
       root.showNextBook();
 
       expect(navigate.mock.calls.length).toBe(1);
@@ -467,14 +467,14 @@ describe("Root", () => {
       let lastIndex = groupedCollectionData.lanes[0].books.length - 1;
       bookData = groupedCollectionData.lanes[0].books[0];
       nextBookData = groupedCollectionData.lanes[0].books[lastIndex];
-      root = TestUtils.renderIntoDocument<Root>(
+      root = TestUtils.renderIntoDocument(
         <Root
           navigate={navigate}
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={jest.genMockFunction()}
           />
-      );
+      ) as Root;
       root.showPrevBook();
 
       expect(navigate.mock.calls.length).toBe(1);
@@ -485,14 +485,14 @@ describe("Root", () => {
     it("navigates to first book if currently showing second book", () => {
       bookData = groupedCollectionData.lanes[0].books[1];
       nextBookData = groupedCollectionData.lanes[0].books[0];
-      root = TestUtils.renderIntoDocument<Root>(
+      root = TestUtils.renderIntoDocument(
         <Root
           navigate={navigate}
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={jest.genMockFunction()}
           />
-      );
+      ) as Root;
       root.showPrevBook();
 
       expect(navigate.mock.calls.length).toBe(1);
@@ -525,7 +525,7 @@ describe("Root", () => {
           navigate={navigate}
           pathFor={pathFor}
           collectionData={collectionData} />
-      );
+      ) as React.Component<any, any>;
       rootInstance = root.getWrappedInstance();
     });
 
@@ -557,7 +557,7 @@ describe("Root", () => {
           navigate={navigate}
           collectionData={collectionData}
           bookData={bookData} />
-      );
+      ) as React.Component<any, any>;
       rootInstance = root.getWrappedInstance();
       let collectionLink = TestUtils.findRenderedDOMComponentWithClass(rootInstance, "currentCollectionLink");
       TestUtils.Simulate.click(collectionLink);

--- a/packages/opds-browser/src/components/__tests__/Search-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Search-test.tsx
@@ -11,7 +11,11 @@ describe("Search", () => {
     let fetchSearchDescription = jest.genMockFunction();
     let url = "test url";
     let search = TestUtils.renderIntoDocument(
-      <Search url={url} fetchSearchDescription={fetchSearchDescription} />
+      <Search
+        url={url}
+        fetchSearchDescription={fetchSearchDescription}
+        navigate={jest.genMockFunction()}
+        />
     );
     expect(fetchSearchDescription.mock.calls.length).toEqual(1);
     expect(fetchSearchDescription.mock.calls[0][0]).toEqual("test url");
@@ -27,11 +31,20 @@ describe("Search", () => {
     };
     let element = document.createElement("div");
     ReactDOM.render(
-      <Search url={url} fetchSearchDescription={fetchSearchDescription} />,
+      <Search
+        url={url}
+        fetchSearchDescription={fetchSearchDescription}
+        navigate={jest.genMockFunction()}
+        />,
       element
     );
     ReactDOM.render(
-      <Search url={url} searchData={searchData} fetchSearchDescription={fetchSearchDescription} />,
+      <Search
+        url={url}
+        searchData={searchData}
+        fetchSearchDescription={fetchSearchDescription}
+        navigate={jest.genMockFunction()}
+        />,
       element
     );
     expect(fetchSearchDescription.mock.calls.length).toEqual(1);
@@ -44,7 +57,7 @@ describe("Search", () => {
       template: (s) => s
     };
     let search = TestUtils.renderIntoDocument(
-      <Search searchData={searchData} />
+      <Search searchData={searchData} navigate={jest.genMockFunction()} />
     );
 
     let form = TestUtils.findRenderedDOMComponentWithTag(search, "form");

--- a/packages/opds-browser/src/components/__tests__/Search-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/Search-test.tsx
@@ -16,7 +16,7 @@ describe("Search", () => {
         fetchSearchDescription={fetchSearchDescription}
         navigate={jest.genMockFunction()}
         />
-    );
+    ) as Search;
     expect(fetchSearchDescription.mock.calls.length).toEqual(1);
     expect(fetchSearchDescription.mock.calls[0][0]).toEqual("test url");
   });
@@ -37,7 +37,7 @@ describe("Search", () => {
         navigate={jest.genMockFunction()}
         />,
       element
-    );
+    ) as Search;
     ReactDOM.render(
       <Search
         url={url}
@@ -58,7 +58,7 @@ describe("Search", () => {
     };
     let search = TestUtils.renderIntoDocument(
       <Search searchData={searchData} navigate={jest.genMockFunction()} />
-    );
+    ) as Search;
 
     let form = TestUtils.findRenderedDOMComponentWithTag(search, "form");
     let input = TestUtils.findRenderedDOMComponentWithTag(search, "input");
@@ -81,7 +81,7 @@ describe("Search", () => {
     };
     let search = TestUtils.renderIntoDocument(
       <Search searchData={searchData} navigate={navigate} />
-    );
+    ) as Search;
 
     let form = TestUtils.findRenderedDOMComponentWithTag(search, "form");
     expect(form).toBeTruthy();
@@ -103,7 +103,7 @@ describe("Search", () => {
     };
     let search = TestUtils.renderIntoDocument(
       <Search searchData={searchData} navigate={navigate} />
-    );
+    ) as Search;
 
     let form = TestUtils.findRenderedDOMComponentWithTag(search, "form");
     expect(form).toBeTruthy();

--- a/packages/opds-browser/src/components/__tests__/SkipNavigationLink-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/SkipNavigationLink-test.tsx
@@ -9,7 +9,7 @@ describe("SkipNavigationLink", () => {
   it("shows link", () => {
     let component = TestUtils.renderIntoDocument(
       <SkipNavigationLink />
-    );
+    ) as SkipNavigationLink;
 
     let element = TestUtils.findRenderedDOMComponentWithClass(component, "skipNavigation");
     expect(element.textContent).toBe("Skip Navigation");

--- a/packages/opds-browser/src/components/__tests__/UrlForm-test.tsx
+++ b/packages/opds-browser/src/components/__tests__/UrlForm-test.tsx
@@ -11,7 +11,7 @@ describe("UrlForm", () => {
     let navigate = jest.genMockFunction();
     let form = TestUtils.renderIntoDocument(
       <UrlForm navigate={navigate} />
-    );
+    ) as UrlForm;
 
     let formNode = TestUtils.findRenderedDOMComponentWithTag(form, "form");
     let input = TestUtils.findRenderedDOMComponentWithTag(form, "input");
@@ -28,7 +28,7 @@ describe("UrlForm", () => {
     let navigate = jest.genMockFunction();
     let urlForm = TestUtils.renderIntoDocument(
       <UrlForm navigate={navigate} />
-    );
+    ) as UrlForm;
 
     let form = TestUtils.findRenderedDOMComponentWithTag(urlForm, "form");
     let input = TestUtils.findRenderedDOMComponentWithTag(urlForm, "input");

--- a/packages/opds-browser/src/components/__tests__/collectionData.ts
+++ b/packages/opds-browser/src/components/__tests__/collectionData.ts
@@ -1,3 +1,5 @@
+import { CollectionData } from "../../interfaces";
+
 let groupedCollectionData: CollectionData = {
   id: "/groups/",
   url: "http://circulation.librarysimplified.org/groups/",

--- a/packages/opds-browser/src/components/mergeRootProps.ts
+++ b/packages/opds-browser/src/components/mergeRootProps.ts
@@ -1,6 +1,7 @@
 import ActionsCreator from "../actions";
 import DataFetcher from "../DataFetcher";
 import { adapter } from "../OPDSDataAdapter";
+import { CollectionData, BookData } from "../interfaces";
 
 export function findBookInCollection(collection: CollectionData, book: string) {
   if (collection) {

--- a/packages/opds-browser/src/interfaces.ts
+++ b/packages/opds-browser/src/interfaces.ts
@@ -1,21 +1,4 @@
-interface BaseProps extends __React.HTMLProps<any> {
-  pathFor?: (collectionUrl: string, bookUrl: string) => string;
-}
-
-interface CollectionActionProps {
-  navigate?: (collectionUrl: string, book: BookData|string, isTopLevel?: boolean) => Promise<any>;
-  fetchPage?: (url: string) => void;
-  isTopLevel?: boolean;
-}
-
-interface BookActionProps {
-  navigate?: (collectionUrl: string, book: BookData|string, isTopLevel?: boolean) => Promise<any>;
-  clearBook?: () => void;
-  book?: BookData;
-  collectionUrl?: string;
-}
-
-interface BookData {
+export interface BookData {
   id: string;
   title: string;
   authors?: string[];
@@ -28,24 +11,24 @@ interface BookData {
   categories?: string[];
 }
 
-interface LaneData {
+export interface LaneData {
   title: string;
   url: string;
   books: BookData[];
 }
 
-interface FacetData {
+export interface FacetData {
   label: string;
   href: string;
   active: boolean;
 }
 
-interface FacetGroupData {
+export interface FacetGroupData {
   label: string;
   facets: FacetData[];
 }
 
-interface CollectionData {
+export interface CollectionData {
   id: string;
   url: string;
   title: string;
@@ -58,7 +41,7 @@ interface CollectionData {
   catalogRootUrl?: string;
 }
 
-interface SearchData extends CollectionActionProps, BaseProps {
+export interface SearchData {
   url?: string;
   searchData?: {
     description: string;
@@ -67,10 +50,16 @@ interface SearchData extends CollectionActionProps, BaseProps {
   };
 }
 
+export interface LinkData {
+  id: string;
+  text: string;
+  url: string;
+}
+
 // these properties need to be optional because they're used by RootProps,
 // which doesn't implement them until Root is connected to the state by redux;
 // initially, Root isn't provided most of these props
-interface State {
+export interface State {
   collectionData?: CollectionData;
   collectionUrl?: string;
   isFetching?: boolean;
@@ -81,13 +70,15 @@ interface State {
   history?: LinkData[];
 }
 
-interface LinkData {
-  id: string;
-  text: string;
-  url: string;
+export interface Navigate {
+  (collectionUrl: string, book: BookData|string, isTopLevel?: boolean): Promise<any>;
 }
 
-interface FetchError {
+export interface PathFor {
+  (collectionUrl: string, bookUrl: string): string;
+}
+
+export interface FetchError {
   status: number;
   response: string;
   url: string;

--- a/packages/opds-browser/src/interfaces.ts
+++ b/packages/opds-browser/src/interfaces.ts
@@ -63,7 +63,7 @@ export interface State {
   collectionData?: CollectionData;
   collectionUrl?: string;
   isFetching?: boolean;
-  error?: FetchError;
+  error?: FetchErrorData;
   bookData?: BookData;
   bookUrl?: string;
   isFetchingPage?: boolean;
@@ -78,7 +78,7 @@ export interface PathFor {
   (collectionUrl: string, bookUrl: string): string;
 }
 
-export interface FetchError {
+export interface FetchErrorData {
   status: number;
   response: string;
   url: string;

--- a/packages/opds-browser/src/interfaces.ts
+++ b/packages/opds-browser/src/interfaces.ts
@@ -71,7 +71,7 @@ export interface State {
 }
 
 export interface Navigate {
-  (collectionUrl: string, book: BookData|string, isTopLevel?: boolean): Promise<any>;
+  (collectionUrl: string, book: BookData|string, isTopLevel?: boolean): void;
 }
 
 export interface PathFor {

--- a/packages/opds-browser/typings.json
+++ b/packages/opds-browser/typings.json
@@ -2,9 +2,9 @@
   "ambientDependencies": {
     "core-js": "github:DefinitelyTyped/DefinitelyTyped/core-js/core-js.d.ts#c777572e8532c4d358306fe4c0e17a533f940b04",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
-    "react": "github:DefinitelyTyped/DefinitelyTyped/react/react.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
-    "react-addons-test-utils": "github:DefinitelyTyped/DefinitelyTyped/react/react-addons-test-utils.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
-    "react-dom": "github:DefinitelyTyped/DefinitelyTyped/react/react-dom.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",
+    "react": "registry:dt/react#0.14.0+20160412154040",
+    "react-addons-test-utils": "registry:dt/react-addons-test-utils#0.14.0+20160316155526",
+    "react-dom": "registry:dt/react-dom#0.14.0+20160412154040",
     "react-redux": "github:DefinitelyTyped/DefinitelyTyped/react-redux/react-redux.d.ts#a513c4df6eb8505da8eef432891c8b69b73535d9",
     "redux": "registry:dt/redux#3.3.1+20160326112656",
     "redux-thunk": "github:DefinitelyTyped/DefinitelyTyped/redux-thunk/redux-thunk.d.ts#75249b97104d00c1ca2451ac29369009a5f2b101",


### PR DESCRIPTION
This branch moves non-prop interfaces from a declaration file to a new file that exports them and requires them to be explicitly imported elsewhere.